### PR TITLE
Improve Japanese Yen detection

### DIFF
--- a/src/Localizations.js
+++ b/src/Localizations.js
@@ -42,7 +42,7 @@ class Localizations {
             // UK
             'GBP': ['£'],
             // Japan
-            'JPY': ['JP¥'],
+            'JPY': ['JP¥', '円'],
             // China
             'CNY': ['元'],
             // India


### PR DESCRIPTION
Add `円` symbol to yen localization.
This makes the extension now work on the following url: 
https://www.jiku-chu.com/products/detail.php?product_id=20935