### PR TITLE
Added Argentine peso as dollar option

### DIFF
--- a/src/components/content/MenuAlert.tsx
+++ b/src/components/content/MenuAlert.tsx
@@ -32,6 +32,7 @@ const dollarOptions = [
     {value: 'NZD', label: 'New Zealand'},
     {value: 'SGP', label: 'Singapore'},
     {value: 'HKD', label: 'Hong kong'},
+    {value: 'ARS', label: 'Argentine'},
 ];
 
 const kroneOptions = [

--- a/src/components/options/Currency/LocalizationCard.tsx
+++ b/src/components/options/Currency/LocalizationCard.tsx
@@ -13,6 +13,7 @@ const dollarOptions = [
     {value: 'NZD', label: 'New Zealand'},
     {value: 'SGP', label: 'Singapore'},
     {value: 'HKD', label: 'Hong kong'},
+    {value: 'ARS', label: 'Argentine peso'},
 ];
 
 const kroneOptions = [

--- a/src/currencyConverter/Localization/Localization.ts
+++ b/src/currencyConverter/Localization/Localization.ts
@@ -13,8 +13,8 @@ export class Localizations {
 
     static get shared() {
         return {
-            // Usa, Canada, Australia, Mexico, New Zealand, Singapore, Hong kong
-            '$': ['USD', 'CAD', 'AUD', 'MXN', 'NZD', 'SGP', 'HKD'],
+            // Usa, Canada, Australia, Mexico, New Zealand, Singapore, Hong kong, Argentine peso
+            '$': ['USD', 'CAD', 'AUD', 'MXN', 'NZD', 'SGP', 'HKD', 'ARS'],
             'dollar': ['USD', 'CAD', 'AUD', 'MXN', 'NZD', 'SGP', 'HKD'],
             'dollars': ['USD', 'CAD', 'AUD', 'MXN', 'NZD', 'SGP', 'HKD'],
             // Denmark, Sweden,  Norway, Island, Czechia


### PR DESCRIPTION
The peso is the currency of Argentina, identified by the symbol $ preceding the amount in the same way as many countries using dollar currencies.